### PR TITLE
mbedtls：fix scalar k intrinsic error when use -O0 compile flag and adjust Makefile for examples

### DIFF
--- a/accelerator/README.md
+++ b/accelerator/README.md
@@ -20,7 +20,7 @@ MIDDLEWARE := mbedtls
 # ARCH_EXT will default provide a required arch controlled by mbedtls/build.mk
 # If you want to override it, you need to pass extra arch ext list below
 # scalar k require ARCH_EXT ?= _zk_zks
-# vector k require ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
+# vector k require ARCH_EXT ?= _zve64x_zvkn_zvks
 MBEDTLS_ACC ?= scalar_k
 ~~~
 

--- a/accelerator/README.md
+++ b/accelerator/README.md
@@ -2,8 +2,8 @@
 
 We provided different optimized accelerator implemention for MbedTLS for Nuclei Hardware.
 
-- **scalar_k**: Optimized for RISC-V Scalar K extension, which is supported by Nuclei RISC-V CPU IP, see [MbedTLS Optimized using RISC-V K extension](scalar_k/README.md).
-- **vector_k**: Optimized for RISC-V Vector K extension, which is supported by Nuclei RISC-V CPU IP, required at least `Zve64x` together with Vector K extension, see [MbedTLS Optimized using RISC-V K extension](vector_k/README.md).
+- **scalar_k**: Optimized for RISC-V Scalar K extension, which is supported by Nuclei RISC-V CPU IP, see [scalar_k/README.md](scalar_k/README.md).
+- **vector_k**: Optimized for RISC-V Vector K extension, which is supported by Nuclei RISC-V CPU IP, required at least `Zve64x` together with Vector K extension, see [vector_k/README.md](vector_k/README.md).
 - **xlcrypto**: Optimized for Nuclei Crypto Engine IP, which can be used with Nuclei RISC-V CPU IP, see [xlcrypto/README.md](xlcrypto/README.md).
 
 For how to use the accelerated implementation, you can do this like this in your application Makefile of Nuclei SDK:
@@ -13,7 +13,9 @@ For how to use the accelerated implementation, you can do this like this in your
 MIDDLEWARE := mbedtls
 
 # Choose mbedtls accelerator
-# scalar_k/vector_k/xlcrypto
+#
+# MBEDTLS_ACC can be selected from scalar_k/vector_k/xlcrypto
+#
 # when scalar_k or vector_k is selected,
 # ARCH_EXT will default provide a required arch controlled by mbedtls/build.mk
 # If you want to override it, you need to pass extra arch ext list below
@@ -22,7 +24,7 @@ MIDDLEWARE := mbedtls
 MBEDTLS_ACC ?= scalar_k
 ~~~
 
-We provided some examples for you to get started with MbedTLS optimized for Nuclei Hardware, see **<mbedtls>/examples** folder.
+We provided some examples for you to get started with MbedTLS optimized for Nuclei Hardware, see **mbedtls/examples** folder.
 
 > **NOTE** only **benchmark** and **selftest** examples works for different accelator implementation.
 >

--- a/accelerator/scalar_k/README.md
+++ b/accelerator/scalar_k/README.md
@@ -8,7 +8,7 @@ Mbed TLS is a C library that implements cryptographic primitives, X.509 certific
 
 **RISC-V K extensions：** include scalar and vector cryptographic extensions, is used to improve the speed of cryptography algorithms and reduce the size of programs.
 
-**Scalar K:**  using general-purpose X registers, so it is lightweight and suitable for RV32 and RV64
+**Scalar K:**  using general-purpose X registers, so it is lightweight and suitable for RV32 and RV64  
 **Vector K:** based on the Vector registers, designed to be highly performant, with large application and server-class cores being the main target
 
 The following crypto algorithms are accelerated：
@@ -79,34 +79,34 @@ The features of Nuclei Mbed TLS are listed below:
 
 - Each `examples/xxx/mbedtls_config.h` includes its own `acc_rvk_config.h`. You can enable the  macros in `examples/xxx/acc_rvk_config.h` to enable risc-v K extension in `accelerator/scalar_k/xxx_alt.c` or `accelerator/vector_k/xxx_alt.c`,  disable it thus turning to software implement in `library/xxx.c`. The macros are as follows:
 
-~~~makefile
-#define MBEDTLS_AES_SETKEY_ENC_ALT
-#define MBEDTLS_AES_SETKEY_DEC_ALT
-#define MBEDTLS_AES_ENCRYPT_ALT
-#define MBEDTLS_AES_DECRYPT_ALT
+  ~~~makefile
+  #define MBEDTLS_AES_SETKEY_ENC_ALT
+  #define MBEDTLS_AES_SETKEY_DEC_ALT
+  #define MBEDTLS_AES_ENCRYPT_ALT
+  #define MBEDTLS_AES_DECRYPT_ALT
 
-#if defined(MBEDTLS_ACC_VECTOR_K)
-#define MBEDTLS_AES_CBC_ALT
-#endif
+  #if defined(MBEDTLS_ACC_VECTOR_K)
+  #define MBEDTLS_AES_CBC_ALT
+  #endif
 
-#define MBEDTLS_SHA256_PROCESS_ALT
-#define MBEDTLS_SHA512_PROCESS_ALT
+  #define MBEDTLS_SHA256_PROCESS_ALT
+  #define MBEDTLS_SHA512_PROCESS_ALT
 
-#if defined(MBEDTLS_ACC_VECTOR_K)
-#define MBEDTLS_SHA256_UPDATE_ALT
-#define MBEDTLS_SHA512_UPDATE_ALT
-#endif
+  #if defined(MBEDTLS_ACC_VECTOR_K)
+  #define MBEDTLS_SHA256_UPDATE_ALT
+  #define MBEDTLS_SHA512_UPDATE_ALT
+  #endif
 
-#define MBEDTLS_SM3_PROCESS_ALT
+  #define MBEDTLS_SM3_PROCESS_ALT
 
-#if defined(MBEDTLS_ACC_VECTOR_K)
-#define MBEDTLS_SM3_UPDATE_ALT
-#endif
+  #if defined(MBEDTLS_ACC_VECTOR_K)
+  #define MBEDTLS_SM3_UPDATE_ALT
+  #endif
 
-#define MBEDTLS_SM4_SETKEY_ENC_ALT
-#define MBEDTLS_SM4_SETKEY_DEC_ALT
-#define MBEDTLS_SM4_CRYPT_ECB_ALT
-~~~
+  #define MBEDTLS_SM4_SETKEY_ENC_ALT
+  #define MBEDTLS_SM4_SETKEY_DEC_ALT
+  #define MBEDTLS_SM4_CRYPT_ECB_ALT
+  ~~~
 
 ## How to use libmbedtls in Terminal
 
@@ -156,20 +156,20 @@ The features of Nuclei Mbed TLS are listed below:
    # scalar K support n300 n900 nx900
    # vector K only support nx900 with _zve64x extension
    # MBEDTLS_ACC could be choosen in {scalar_k, vector_k, xlcrypt}, if set MBEDTLS_ACC None, means has no acceleration
-   make CORE=nx900 MBEDTLS_ACC=scalar_k DOWNLOAD=ddr all
+   $ make CORE=nx900 MBEDTLS_ACC=scalar_k DOWNLOAD=ddr all
    # or
-   make CORE=nx900 MBEDTLS_ACC=vector_k DOWNLOAD=ddr all
+   $ make CORE=nx900 MBEDTLS_ACC=vector_k DOWNLOAD=ddr all
    # or
-   make CORE=nx900 MBEDTLS_ACC= DOWNLOAD=ddr all  # no acceleration
+   $ make CORE=nx900 MBEDTLS_ACC= DOWNLOAD=ddr all  # no acceleration
    
    # Upload
    # upload to fpga
-   make CORE=nx900 DOWNLOAD=ddr upload
-   # or qemu, Note: qemu don't support vector_k at this time
-   make CORE=nx900 DOWNLOAD=ddr run_qemu
+   $ make CORE=nx900 DOWNLOAD=ddr upload
+   # or qemu, Note: qemu don't support vector_k at now
+   $ make CORE=nx900 DOWNLOAD=ddr run_qemu
    ~~~
    
-   **Note:** if you built with `DOWNLOAD=ilm`, please use 512K ilm/dlm,  **make sure your cpu bitstream configured with 512K ILM/DLM if you want to run on hardware **.
+   **Note:** if you built with `DOWNLOAD=ilm`,  **make sure your cpu bitstream configured with 512K ILM/DLM if you want to run on hardware**.
    
    ~~~sh
    # file: /path/to/nuclei_sdk/SoC/evalsoc/Board/nuclei_fpga_eval/Source/GCC/gcc_evalsoc_ilm.ld
@@ -190,15 +190,19 @@ Here are the logs of *Components/mbedtls/examples/selftest* in NX900 FPGA，DOWN
 
 ~~~sh
 $ make CORE=nx900 MBEDTLS_ACC=scalar_k DOWNLOAD=ilm all
+
 $ make CORE=nx900 MBEDTLS_ACC=scalar_k DOWNLOAD=ilm upload
+
+# or qemu, Note: qemu don't support vector_k at now
+$ make CORE=nx900 DOWNLOAD=ilm run_qemu
 ~~~
 
-log as follows(with deletion):
+Logs running on nx900 FPGA are as follows(in brief):
 ~~~log
-Nuclei SDK Build Time: May 21 2024, 18:07:24
-Download Mode: ILM
-CPU Frequency 50322800 Hz
-CPU HartID: 0
+  Nuclei SDK Build Time: May 21 2024, 18:07:24
+  Download Mode: ILM
+  CPU Frequency 50322800 Hz
+  CPU HartID: 0
 
   SHA-224 test #1: passed
   SHA-224 test #2: passed
@@ -300,7 +304,8 @@ CPU HartID: 0
 
 ## How to use libmbedtls in Nuclei Studio IDE
 
-1. Download Nuclei Studio IDE from https://www.nucleisys.com/download.php, please refer to https://www.nucleisys.com/upload/files/doc/nucleistudio/Nuclei_Studio_User_Guide_202402.pdf to get the detailed usage of Nuclei Studio IDE.
+1. Download Nuclei Studio IDE from https://www.nucleisys.com/download.php,  
+   please refer to https://www.nucleisys.com/upload/files/doc/nucleistudio/Nuclei_Studio_User_Guide_202402.pdf to get the detailed usage of Nuclei Studio IDE.
 
    ![Download_IDE](asserts/Download_IDE.png)
 
@@ -310,7 +315,7 @@ CPU HartID: 0
 
 
 
-3. Get **libmbedtls** zip package from https://github.com/Nuclei-Software/mbedtls , and import the zip package of **libmbedtls** until the Status is installed:
+3. Get **libmbedtls** zip package from https://github.com/Nuclei-Software/mbedtls , and import the zip package of **libmbedtls** until the Status is installed.
 
 ![npk_libmbedtls_import](asserts/npk_libmbedtls_import.png)
 
@@ -338,7 +343,7 @@ CPU HartID: 0
 
   
 
-**Note:** if you built with `DOWNLOAD=ilm`, please use 512K ilm/dlm,  **make sure your cpu bitstream configured with 512K ILM/DLM if you want to run on hardware **, and modify `nuclei_sdk/SoC/evalsoc/Board/nuclei_fpga_eval/Source/GCC/gcc_evalsoc_ilm.ld`
+**Note:** if you built with `DOWNLOAD=ilm`, please use 512K ilm/dlm,  **make sure your cpu bitstream configured with 512K ILM/DLM if you want to run on hardware**, and modify `nuclei_sdk/SoC/evalsoc/Board/nuclei_fpga_eval/Source/GCC/gcc_evalsoc_ilm.ld`
 
 ## Data performance
 

--- a/accelerator/scalar_k/share/riscv-crypto-intrinsics.h
+++ b/accelerator/scalar_k/share/riscv-crypto-intrinsics.h
@@ -53,14 +53,67 @@ static inline uint_xlen_t _sha512sum1 (uint_xlen_t rs1) {uint_xlen_t rd; __asm__
 //
 
 #if (defined(__ZSCRYPTO) && defined(RISCV_CRYPTO_RV32))
+/*
 static inline uint_xlen_t _aes32esi (uint_xlen_t rs1, uint_xlen_t rs2, int bs) {uint_xlen_t rd; __asm__("aes32esi  %0, %1, %2, %3" : "=r"(rd) : "r"(rs1), "r"(rs2), "i"(bs)); return rd;}
+*/
+#define _aes32esi(rs1, rs2, bs)    \
+    ({    \
+        uint_xlen_t __rs1 = (uint_xlen_t)(rs1);      \
+        uint_xlen_t __rs2 = (uint_xlen_t)(rs2);      \
+        uint_xlen_t __rd;                            \
+        __asm__("aes32esi  %0, %1, %2, %3" : "=r"(__rd) : "r"(__rs1), "r"(__rs2), "i"(bs));   \
+        __rd;    \
+    })
+/*
 static inline uint_xlen_t _aes32esmi(uint_xlen_t rs1, uint_xlen_t rs2, int bs) {uint_xlen_t rd; __asm__("aes32esmi %0, %1, %2, %3" : "=r"(rd) : "r"(rs1), "r"(rs2), "i"(bs)); return rd;}
+*/
+#define _aes32esmi(rs1, rs2, bs)    \
+    ({    \
+        uint_xlen_t __rs1 = (uint_xlen_t)(rs1);      \
+        uint_xlen_t __rs2 = (uint_xlen_t)(rs2);      \
+        uint_xlen_t __rd;                            \
+        __asm__("aes32esmi %0, %1, %2, %3" : "=r"(__rd) : "r"(__rs1), "r"(__rs2), "i"(bs));   \
+        __rd;    \
+    })
+
+/*
 static inline uint_xlen_t _aes32dsi (uint_xlen_t rs1, uint_xlen_t rs2, int bs) {uint_xlen_t rd; __asm__("aes32dsi  %0, %1, %2, %3" : "=r"(rd) : "r"(rs1), "r"(rs2), "i"(bs)); return rd;}
+*/
+#define _aes32dsi(rs1, rs2, bs)    \
+    ({    \
+        uint_xlen_t __rs1 = (uint_xlen_t)(rs1);      \
+        uint_xlen_t __rs2 = (uint_xlen_t)(rs2);      \
+        uint_xlen_t __rd;                            \
+        __asm__("aes32dsi  %0, %1, %2, %3" : "=r"(__rd) : "r"(__rs1), "r"(__rs2), "i"(bs));   \
+        __rd;    \
+    })
+
+/*
 static inline uint_xlen_t _aes32dsmi(uint_xlen_t rs1, uint_xlen_t rs2, int bs) {uint_xlen_t rd; __asm__("aes32dsmi %0, %1, %2, %3" : "=r"(rd) : "r"(rs1), "r"(rs2), "i"(bs)); return rd;}
+*/
+#define _aes32dsmi(rs1, rs2, bs)    \
+    ({    \
+        uint_xlen_t __rs1 = (uint_xlen_t)(rs1);      \
+        uint_xlen_t __rs2 = (uint_xlen_t)(rs2);      \
+        uint_xlen_t __rd;                            \
+        __asm__("aes32dsmi %0, %1, %2, %3" : "=r"(__rd) : "r"(__rs1), "r"(__rs2), "i"(bs));   \
+        __rd;    \
+    })
+
 #endif
 
 #if (defined(__ZSCRYPTO) && defined(RISCV_CRYPTO_RV64))
+/*
 static inline uint_xlen_t _aes64ks1i  (uint_xlen_t rs1, int      rnum) {uint_xlen_t rd; __asm__("aes64ks1i %0, %1, %2" : "=r"(rd) : "r"(rs1), "i"(rnum)); return rd;}
+*/
+#define _aes64ks1i(rs1, rnum)    \
+    ({    \
+        uint_xlen_t __rs1 = (uint_xlen_t)(rs1);      \
+        uint_xlen_t __rd;                            \
+        __asm__("aes64ks1i %0, %1, %2" : "=r"(__rd) : "r"(__rs1), "i"(rnum));    \
+        __rd;    \
+    })
+
 static inline uint_xlen_t _aes64ks2   (uint_xlen_t rs1, uint_xlen_t rs2 ) {uint_xlen_t rd; __asm__("aes64ks2  %0, %1, %2" : "=r"(rd) : "r"(rs1), "r"(rs2 )); return rd;}
 static inline uint_xlen_t _aes64im    (uint_xlen_t rs1               ) {uint_xlen_t rd; __asm__("aes64im   %0, %1    " : "=r"(rd) : "r"(rs1)           ); return rd;}
 static inline uint_xlen_t _aes64esm   (uint_xlen_t rs1, uint_xlen_t rs2 ) {uint_xlen_t rd; __asm__("aes64esm  %0, %1, %2" : "=r"(rd) : "r"(rs1), "r"(rs2 )); return rd;}
@@ -74,8 +127,31 @@ static inline uint_xlen_t _aes64ds    (uint_xlen_t rs1, uint_xlen_t rs2 ) {uint_
 //
 
 #if (defined(__ZSCRYPTO))
+/*
 static inline uint_xlen_t _sm4ks (uint_xlen_t rs1, uint_xlen_t rs2, int bs) {uint_xlen_t rd; __asm__("sm4ks %0, %1, %2, %3" : "=r"(rd) : "r"(rs1), "r"(rs2), "i"(bs)); return rd;}
+*/
+#define _sm4ks(rs1, rs2, bs)    \
+    ({    \
+        uint_xlen_t __rs1 = (uint_xlen_t)(rs1);      \
+        uint_xlen_t __rs2 = (uint_xlen_t)(rs2);      \
+        uint_xlen_t __rd;                            \
+        __asm__("sm4ks %0, %1, %2, %3" : "=r"(__rd) : "r"(__rs1), "r"(__rs2), "i"(bs));    \
+        __rd;    \
+    })
+
+/*
 static inline uint_xlen_t _sm4ed (uint_xlen_t rs1, uint_xlen_t rs2, int bs) {uint_xlen_t rd; __asm__("sm4ed %0, %1, %2, %3" : "=r"(rd) : "r"(rs1), "r"(rs2), "i"(bs)); return rd;}
+*/
+
+#define _sm4ed(rs1, rs2, bs)    \
+    ({    \
+        uint_xlen_t __rs1 = (uint_xlen_t)(rs1);      \
+        uint_xlen_t __rs2 = (uint_xlen_t)(rs2);      \
+        uint_xlen_t __rd;                            \
+        __asm__("sm4ed %0, %1, %2, %3" : "=r"(__rd) : "r"(__rs1), "r"(__rs2), "i"(bs));    \
+        __rd;    \
+    })
+
 #endif
 
 //

--- a/accelerator/xlcrypto/README.md
+++ b/accelerator/xlcrypto/README.md
@@ -184,14 +184,14 @@ The features of Nuclei Mbed TLS are listed below:
 
    - If you want to build your application, you can easily run this command:
 
-     ```c
-     make CORE=n300 DOWNLOAD=sram all
+     ```shell
+     $ make CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=sram all
      ```
 
    - If you want to upload your application, you can easily run this command:
 
-     ```c
-     make CORE=n300 DOWNLOAD=sram upload
+     ```shell
+     $ make CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=sram upload
      ```
 
    - If you want to use UART terminal tool to view the application result, you can choose `screen` or `minicom` in Linux, `teraterm` in Windows, the default UART baudrate we use is `115200`. For example, test all HASH-related algorithm in *Components/mbedtls/examples/selftest* as follows:

--- a/build.mk
+++ b/build.mk
@@ -22,7 +22,6 @@ ifeq ($(MBEDTLS_ACC),scalar_k)
 C_SRCDIRS += $(MBEDTLS_ROOT)/accelerator/scalar_k
 INCDIRS += $(MBEDTLS_ROOT)/accelerator/scalar_k
 COMMON_FLAGS += -D__ZSCRYPTO -DRVINTRIN_EMULATE=1
-ARCH_EXT ?= _zk_zks
 ifneq ($(findstring x, $(CORE)),)
 C_SRCDIRS += $(MBEDTLS_ROOT)/accelerator/scalar_k/zscrypto_rv64
 ASM_SRCDIRS += $(MBEDTLS_ROOT)/accelerator/scalar_k/zscrypto_rv64
@@ -36,8 +35,6 @@ ifeq ($(MBEDTLS_ACC),vector_k)
 C_SRCDIRS += $(MBEDTLS_ROOT)/accelerator/vector_k
 ASM_SRCDIRS += $(MBEDTLS_ROOT)/accelerator/vector_k
 INCDIRS += $(MBEDTLS_ROOT)/accelerator/vector_k
-# require at least _zve64x for vector k, so _zve32* is not supported
-ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
 endif
 
 INCDIRS += $(MBEDTLS_ROOT)/include $(MBEDTLS_ROOT)/library $(MBEDTLS_ROOT)/tests/include

--- a/examples/benchmark/Makefile
+++ b/examples/benchmark/Makefile
@@ -18,6 +18,14 @@ STDCLIB ?= newlib_full
 # vector k require ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
 MBEDTLS_ACC ?= scalar_k
 
+ifeq ($(MBEDTLS_ACC),scalar_k)
+ARCH_EXT ?= _zk_zks
+endif
+
+ifeq ($(MBEDTLS_ACC),vector_k)
+# require at least _zve64x for vector k, so _zve32* is not supported
+ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
+endif
 SRCDIRS = .
 
 INCDIRS = .

--- a/examples/benchmark/Makefile
+++ b/examples/benchmark/Makefile
@@ -15,7 +15,7 @@ STDCLIB ?= newlib_full
 # ARCH_EXT will default provide a required arch controlled by mbedtls/build.mk
 # If you want to override it, you need to pass extra arch ext list below
 # scalar k require ARCH_EXT ?= _zk_zks
-# vector k require ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
+# vector k require ARCH_EXT ?= _zve64x_zvkn_zvks
 MBEDTLS_ACC ?= scalar_k
 
 ifeq ($(MBEDTLS_ACC),scalar_k)
@@ -24,8 +24,9 @@ endif
 
 ifeq ($(MBEDTLS_ACC),vector_k)
 # require at least _zve64x for vector k, so _zve32* is not supported
-ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
+ARCH_EXT ?= _zve64x_zvkn_zvks
 endif
+
 SRCDIRS = .
 
 INCDIRS = .

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -4,7 +4,9 @@
 
 This directory contains benchmark example files.
 
-This example describes benchmark testing process and exports benchmark result of each crypto algorithm. Each crypto algorithm can be accelerated by Nuclei hardware engine, they are as follows:
+This example describes benchmark testing process and exports benchmark result of each crypto algorithm.
+
+Accelerated by  Nuclei Crypto Engine IP(**xlcrypto**), algorithms are as follows, please refer to `mbedtls/accelerator/xlcrypto/README.md` for more details:
 
 - MD5
 - SHA1
@@ -18,23 +20,49 @@ This example describes benchmark testing process and exports benchmark result of
 - ECDSA
 - ECDH
 
-You can select the hardware acceleration of the corresponding algorithm by enabling the acceleration macros in `acc_config.h`, compile and run the example and compare hardware and software benchmark result. Please refer to `mbedtls/accelerator/xlcrypto/README.md` for more details.
+Accelerated by  RISC-V K extensions(**scalar_k** and **vector_k**), algorithms are as follows, please refer to `mbedtls/accelerator/scalar_k/README.md` for more details:
+
+- SHA224/SHA256
+- SHA384/SHA512
+- AES-CBC
+- AES-GCM
+- AES-CCM
+- SM3
+- SM4 CBC
 
 ## How to run this application
 
-    # Assume that you can set up the Tools and Nuclei SDK environment
-    # cd to the cuttent directory
-    cd examples/benchmark
-    # Clean the application first
-    make SOC=ns DOWNLOAD=sram clean
-    # Build and upload the application
-    make SOC=ns DOWNLOAD=sram upload
+```sh
+# Assume that you can set up the Tools and Nuclei SDK environment
+$ cd examples/benchmark
 
-## Expected output as below:(HASH/CRYP with UDMA accelerated)
+# Running on Nuclei Crypto Engine IP, assume that you use ns subsystem
+# Clean the application first
+$ make SOC=ns CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=sram clean
+# Build and upload the application
+$ make SOC=ns CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=sram upload
 
-Nuclei SDK Build Time: Dec  8 2022, 18:01:33
-Download Mode: SRAM
-CPU Frequency 32000403 Hz
+# Running on RISC-V scalar_k extension
+# Clean the application first
+$ make SOC=evalsoc CORE=nx900 MBEDTLS_ACC=scalar_k DOWNLOAD=sram clean
+# Build and upload the application
+$ make SOC=evalsoc CORE=nx900 MBEDTLS_ACC=scalar_k DOWNLOAD=sram upload
+
+# Running on RISC-V vector_k extension
+# Clean the application first
+$ make SOC=evalsoc CORE=nx900 MBEDTLS_ACC=vector_k DOWNLOAD=sram clean
+# Build and upload the application
+$ make SOC=evalsoc CORE=nx900 MBEDTLS_ACC=vector_k DOWNLOAD=sram upload
+```
+
+## Expected output as below:
+
+**HASH/CRYP with UDMA accelerated:**
+
+~~~log
+    Nuclei SDK Build Time: Dec  8 2022, 18:01:33
+    Download Mode: SRAM
+    CPU Frequency 32000403 Hz
 
     MD5                      :  14562 KiB/s, 2 cycles/byte
     SHA-1                    :  13464 KiB/s, 2 cycles/byte
@@ -90,3 +118,4 @@ CPU Frequency 32000403 Hz
     ECDHE-secp192k1          :  27  full handshake/s
     ECDHE-x25519             :  22  full handshake/s
     ECDHE-x448               :  6  full handshake/s
+~~~

--- a/examples/hmac_demo/Makefile
+++ b/examples/hmac_demo/Makefile
@@ -10,13 +10,6 @@ MIDDLEWARE := mbedtls
 STDCLIB ?= newlib_full
 
 # Choose mbedtls accelerator
-# scalar_k/vector_k/xlcrypto
-# when scalar_k or vector_k is selected,
-# ARCH_EXT will default provide a required arch controlled by mbedtls/build.mk
-# If you want to override it, you need to pass extra arch ext list below
-# scalar k require ARCH_EXT ?= _zba_zbb_zbc_zbs_zk_zks
-# vector k require ARCH_EXT ?= _zve64x_zvbb_zvbc_zvkg_zvkned_zvknhb_zvksed_zvksh
-#
 # NOTE: this example only works with xlcrypto
 MBEDTLS_ACC ?= xlcrypto
 

--- a/examples/hmac_demo/README.md
+++ b/examples/hmac_demo/README.md
@@ -1,5 +1,7 @@
 # README for hmac_demo
 
+**Note:** This demo only support Nuclei Crypto Engine IP,  not risc-v K extensions.
+
 ## Introduction
 
 This directory contains hmac_demo example files. This example describles two hmac process and outputs success or not.
@@ -19,17 +21,20 @@ You can select the hardware acceleration of the corresponding algorithm by enabl
 
 ## How to run this application
 
+~~~shell
     # Assume that you can set up the Tools and Nuclei SDK environment
     # Assume that you use ns subsystem
     # cd to the cuttent directory
-    cd examples/hmac_demo
+    $ cd examples/hmac_demo
     # Clean the application first
-    make SOC=ns DOWNLOAD=ilm clean
+    $ make SOC=ns CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=ilm clean
     # Build and upload the application
-    make SOC=ns DOWNLOAD=ilm upload
+    $ make SOC=ns CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=ilm upload
+~~~
 
 ## Expected output as below
 
+~~~log
     Nuclei SDK Build Time: May 23 2024, 16:07:21
     Download Mode: ILM
     CPU Frequency 30000031 Hz
@@ -52,3 +57,4 @@ You can select the hardware acceleration of the corresponding algorithm by enabl
     Testing MD algorithm: SHA512
     0 HMAC success
     1 HMAC success
+~~~

--- a/examples/rsa8192_demo/Makefile
+++ b/examples/rsa8192_demo/Makefile
@@ -1,6 +1,6 @@
 TARGET = rsa8192_demo
 
-CORE ?= nx900fd
+CORE ?= n300fd
 
 NUCLEI_SDK_ROOT ?= ../../../..
 
@@ -10,13 +10,6 @@ MIDDLEWARE := mbedtls
 STDCLIB ?= newlib_full
 
 # Choose mbedtls accelerator
-# scalar_k/vector_k/xlcrypto
-# when scalar_k or vector_k is selected,
-# ARCH_EXT will default provide a required arch controlled by mbedtls/build.mk
-# If you want to override it, you need to pass extra arch ext list below
-# scalar k require ARCH_EXT ?= _zba_zbb_zbc_zbs_zk_zks
-# vector k require ARCH_EXT ?= _zve64x_zvbb_zvbc_zvkg_zvkned_zvknhb_zvksed_zvksh
-#
 # NOTE: this example only works with xlcrypto
 MBEDTLS_ACC ?= xlcrypto
 

--- a/examples/rsa8192_demo/README.md
+++ b/examples/rsa8192_demo/README.md
@@ -1,5 +1,7 @@
 # README for rsa8192_demo
 
+**Note:** This demo only support Nuclei Crypto Engine IP,  not risc-v K extensions.
+
 ## Introduction
 
 This directory contains rsa8192_demo example files. This demo describes PKCS#1 encryption, decryption and signature verification for RSA8192.
@@ -10,26 +12,31 @@ You can select the hardware acceleration of the corresponding algorithm by enabl
 
 ## How to run this application
 
-    # Assume that you can set up the Tools and Nuclei SDK environment
-    # Assume that you use ns subsystem
-    # cd to the cuttent directory
-    cd examples/rsa8192_demo
-    # Clean the application first
-    make SOC=ns DOWNLOAD=ilm clean
-    # Build and upload the application
-    make SOC=ns DOWNLOAD=ilm upload
+```shell
+# Assume that you can set up the Tools and Nuclei SDK environment
+# Assume that you use ns subsystem
+# cd to the cuttent directory
+$ cd examples/rsa8192_demo
+# Clean the application first
+$ make SOC=ns CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=ilm clean
+# Build and upload the application
+$ make SOC=ns CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=ilm upload
+```
 
 ## Expected output as below
 
-    Nuclei SDK Build Time: Dec 23 2022, 15:21:38
-    Download Mode: ILM
-    CPU Frequency 32000416 Hz
-    RSA8192 key validation: passed
-    PKCS#1 encryption : passed
-    PKCS#1 decryption : passed
-    PKCS#1 data sign  : passed
-    PKCS#1 sig. verify: passed
+```log
+Nuclei SDK Build Time: Dec 23 2022, 15:21:38
+Download Mode: ILM
+CPU Frequency 32000416 Hz
+RSA8192 key validation: passed
+PKCS#1 encryption : passed
+PKCS#1 decryption : passed
+PKCS#1 data sign  : passed
+PKCS#1 sig. verify: passed
 
-    Executed 1 test suites
+Executed 1 test suites
 
-    [ All tests PASS ]
+[ All tests PASS ]
+```
+

--- a/examples/selftest/Makefile
+++ b/examples/selftest/Makefile
@@ -18,6 +18,14 @@ STDCLIB ?= newlib_full
 # vector k require ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
 MBEDTLS_ACC ?= scalar_k
 
+ifeq ($(MBEDTLS_ACC),scalar_k)
+ARCH_EXT ?= _zk_zks
+endif
+
+ifeq ($(MBEDTLS_ACC),vector_k)
+# require at least _zve64x for vector k, so _zve32* is not supported
+ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
+endif
 SRCDIRS = .
 
 INCDIRS = .

--- a/examples/selftest/Makefile
+++ b/examples/selftest/Makefile
@@ -15,7 +15,7 @@ STDCLIB ?= newlib_full
 # ARCH_EXT will default provide a required arch controlled by mbedtls/build.mk
 # If you want to override it, you need to pass extra arch ext list below
 # scalar k require ARCH_EXT ?= _zk_zks
-# vector k require ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
+# vector k require ARCH_EXT ?= _zve64x_zvkn_zvks
 MBEDTLS_ACC ?= scalar_k
 
 ifeq ($(MBEDTLS_ACC),scalar_k)
@@ -24,8 +24,9 @@ endif
 
 ifeq ($(MBEDTLS_ACC),vector_k)
 # require at least _zve64x for vector k, so _zve32* is not supported
-ARCH_EXT ?= _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
+ARCH_EXT ?= _zve64x_zvkn_zvks
 endif
+
 SRCDIRS = .
 
 INCDIRS = .

--- a/examples/selftest/README.md
+++ b/examples/selftest/README.md
@@ -4,7 +4,7 @@
 
 This directory contains selftest example files.
 
-This example describes each crypto algorithm selftest process, you can use this example to verify the correctness of the hardware acceleration of the crypto algorithm. The crypto algorithms are as follows:
+This example describes each crypto algorithm selftest process, you can use this example to verify the correctness of scalar_k/vector_k/xlcrypto of the crypto algorithm. The crypto algorithms are as follows:
 
 - MD5
 - SHA1
@@ -27,20 +27,40 @@ This example describes each crypto algorithm selftest process, you can use this 
 - ECC SHORT WEIERSTRASS
 - ECC MONTGOMERY
 
-You can select the hardware acceleration of the corresponding algorithm by enabling the acceleration macros in `acc_config.h`, compile and run the example using hardware engine or software implement. Please refer to `mbedtls/accelerator/xlcrypto/README.md` for more details.
+**scalar_k:**  please refer to [scalar_k/README.md](scalar_k/README.md).
+
+**vector_k:** please refer to [vector_k/README.md](vector_k/README.md).
+
+**xlcrypto:** please refer to [xlcrypto/README.md](xlcrypto/README.md).
 
 ## How to run this application
 
-    # Assume that you can set up the Tools and Nuclei SDK environment
-    # cd to the cuttent directory
-    cd examples/selftest
-    # Clean the application first
-    make SOC=ns DOWNLOAD=sram clean
-    # Build and upload the application
-    make SOC=ns DOWNLOAD=sram upload
+```shell
+# Assume that you can set up the Tools and Nuclei SDK environment
+$ cd examples/selftest
+
+# Running on Nuclei Crypto Engine IP, assume that you use ns subsystem
+# Clean the application first
+$ make SOC=ns CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=sram clean
+# Build and upload the application
+$ make SOC=ns CORE=n300 MBEDTLS_ACC=xlcrypto DOWNLOAD=sram upload
+
+# Running on RISC-V scalar_k extension
+# Clean the application first
+$ make SOC=evalsoc CORE=nx900 MBEDTLS_ACC=scalar_k DOWNLOAD=sram clean
+# Build and upload the application
+$ make SOC=evalsoc CORE=nx900 MBEDTLS_ACC=scalar_k DOWNLOAD=sram upload
+
+# Running on RISC-V vector_k extension
+# Clean the application first
+$ make SOC=evalsoc CORE=nx900 MBEDTLS_ACC=vector_k DOWNLOAD=sram clean
+# Build and upload the application
+$ make SOC=evalsoc CORE=nx900 MBEDTLS_ACC=vector_k DOWNLOAD=sram upload
+```
 
 ## Expected output as below:
 
+~~~log
     Nuclei SDK Build Time: Dec  7 2022, 21:27:22
     Download Mode: SRAM
     CPU Frequency 32000403 Hz
@@ -175,3 +195,4 @@ You can select the hardware acceleration of the corresponding algorithm by enabl
     Executed 12 test suites
 
     [ All tests PASS ]
+~~~

--- a/npk.yml
+++ b/npk.yml
@@ -39,7 +39,7 @@ setconfig:
     value: _zk_zks
     condition: $( ${mbedtls_acc} == "scalar_k" )
   - config: nuclei_archext
-    value: _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh
+    value: _zve64x_zvkn_zvks
     condition: $( ${mbedtls_acc} == "vector_k" )
 
 ## Source Code Management


### PR DESCRIPTION
## Description

1. mbedtls/scalar_k: fix intrinsics error when use -O0 compile flag
2. mbedtls/examples: adjust Makefile for examples
3. mbedtls/vector_k: Simplify _zve64x_zvbb_zvkg_zvkned_zvknhb_zvksed_zvksh to _zve64x_zvkn_zvks





